### PR TITLE
Allow named exports

### DIFF
--- a/examples/chost.c
+++ b/examples/chost.c
@@ -66,10 +66,10 @@ main(int argc, char *argv[])
     puts("Host start");
 
     andrea_module module1;
-    TRY_STEP(module1, _try_load_module("module1"));
+    TRY_STEP(module1, _try_load_module("module1.exe"));
 
     andrea_module module2;
-    TRY_STEP(module2, _try_load_module("module2"));
+    TRY_STEP(module2, _try_load_module("module2.exe"));
 
     lpfnsquare square;
     TRY_STEP(square, (lpfnsquare)_try_get_procedure(module1, 1));

--- a/examples/chost.c
+++ b/examples/chost.c
@@ -28,13 +28,20 @@ _try_get_procedure(andrea_module module, uint16_t ordinal)
     if (0 == procedure)
     {
         fprintf(stderr, "Cannot get procedure %u of %04X!\n", ordinal, module);
-    }
-    else
-    {
-        printf("Got procedure %u: %04X:%04X\n", ordinal, FP_SEG(procedure),
-               FP_OFF(procedure));
+        goto end;
     }
 
+    printf("Got procedure %u: %04X:%04X", ordinal, FP_SEG(procedure),
+           FP_OFF(procedure));
+
+    char name[32];
+    if (andrea_get_procedure_name(procedure, name, sizeof(name)))
+    {
+        printf(" (%s)", name);
+    }
+    puts("");
+
+end:
     return procedure;
 }
 

--- a/examples/chost.c
+++ b/examples/chost.c
@@ -22,22 +22,23 @@ _try_load_module(const char *name)
 }
 
 static void far *
-_try_get_procedure(andrea_module module, uint16_t ordinal)
+_try_get_procedure(andrea_module module, const char far *name)
 {
-    void far *procedure = andrea_get_procedure(module, ordinal);
+    void far *procedure = andrea_get_procedure(module, name);
     if (0 == procedure)
     {
-        fprintf(stderr, "Cannot get procedure %u of %04X!\n", ordinal, module);
+        fprintf(stderr, "Cannot get procedure %04X:%04X of %04X!\n",
+                FP_SEG(name), FP_OFF(name), module);
         goto end;
     }
 
-    printf("Got procedure %u: %04X:%04X", ordinal, FP_SEG(procedure),
-           FP_OFF(procedure));
+    printf("Got procedure %04X:%04X: %04X:%04X", FP_SEG(name), FP_OFF(name),
+           FP_SEG(procedure), FP_OFF(procedure));
 
-    char name[32];
-    if (andrea_get_procedure_name(procedure, name, sizeof(name)))
+    char proc_name[32];
+    if (andrea_get_procedure_name(procedure, proc_name, sizeof(proc_name)))
     {
-        printf(" (%s)", name);
+        printf(" (%s)", proc_name);
     }
     puts("");
 
@@ -72,14 +73,15 @@ main(int argc, char *argv[])
     TRY_STEP(module2, _try_load_module("module2.exe"));
 
     lpfnsquare square;
-    TRY_STEP(square, (lpfnsquare)_try_get_procedure(module1, 1));
+    TRY_STEP(square,
+             (lpfnsquare)_try_get_procedure(module1, ANDREA_ORDINAL(1)));
 
     STEP("Call square", printf("42 squared is %d\n", square(42)));
 
     STEP("Free module1", andrea_free(module1));
 
     lpfnhello hello;
-    TRY_STEP(hello, (lpfnhello)_try_get_procedure(module2, 1));
+    TRY_STEP(hello, (lpfnhello)_try_get_procedure(module2, "hello"));
 
     STEP("Call hello", hello());
 

--- a/include/andrea.h
+++ b/include/andrea.h
@@ -1,17 +1,9 @@
 #ifndef _ANDREA_H_
 #define _ANDREA_H_
 
-#include <assert.h>
 #include <i86.h>
-#include <stdint.h>
 
-#ifndef far
-#ifdef EDITING
-#define far
-#else // EDITING
-#define far __far
-#endif // EDITING
-#endif // far
+#include <dosdef.h>
 
 typedef unsigned far (*andrea_registration_callback)(uint16_t far *);
 typedef uint16_t andrea_module;
@@ -30,37 +22,6 @@ typedef enum
     ANDREA_ERROR_TOO_MANY_MODULES = 0x82,
     ANDREA_ERROR_NO_EXPORTS = 0x83,
 } andrea_status;
-
-typedef enum
-{
-    STDOUT = 1,
-    STDERR = 2,
-} dos_stream;
-
-#pragma pack(push, 1)
-typedef struct
-{
-    char      int20h[2];
-    uint16_t  seg_tail;
-    uint8_t   _reserved1;
-    char      dispatch[5];
-    void far *intv_terminate;
-    void far *intv_break;
-    void far *intv_error;
-    char      _reserved2[22];
-    uint16_t  seg_environment;
-    char      _reserved3[34];
-    char      int21h_retf[3];
-    char      _reserved4[9];
-    char      fcb1[16];
-    char      fcb2[20];
-    uint8_t   cmdline_len;
-    char      cmdline[127];
-} dos_psp;
-#pragma pack(pop)
-
-static_assert(256 == sizeof(dos_psp),
-              "DOS PSP size doesn't match specification");
 
 extern andrea_module
 andrea_load(const char *name);

--- a/include/andrea.h
+++ b/include/andrea.h
@@ -34,6 +34,9 @@ andrea_free(andrea_module module);
 extern void far *
 andrea_get_procedure(andrea_module module, uint16_t ordinal);
 
+extern size_t
+andrea_get_procedure_name(void far *procedure, char *buffer, size_t size);
+
 #ifdef ANDREA_LOGS_ENABLE
 
 extern void

--- a/include/andrea.h
+++ b/include/andrea.h
@@ -10,7 +10,9 @@ typedef uint16_t andrea_module;
 
 #define ANDREA_EXPORT(name)                                                    \
     __attribute__((section(".preinit"))) const uint16_t __exptbl_##name =      \
-        FP_OFF(name);
+        FP_OFF(name);                                                          \
+    __attribute__((section(".preinit.str"))) const char __expstr_##name[] =    \
+        #name;
 
 #define ANDREA_MAX_MODULES 5
 

--- a/include/andrea.h
+++ b/include/andrea.h
@@ -14,6 +14,8 @@ typedef uint16_t andrea_module;
     __attribute__((section(".preinit.str"))) const char __expstr_##name[] =    \
         #name;
 
+#define ANDREA_ORDINAL(ordinal) ((const char far *)(ordinal))
+
 #define ANDREA_MAX_MODULES 5
 
 typedef enum
@@ -32,7 +34,7 @@ extern void
 andrea_free(andrea_module module);
 
 extern void far *
-andrea_get_procedure(andrea_module module, uint16_t ordinal);
+andrea_get_procedure(andrea_module module, const char far *name);
 
 extern size_t
 andrea_get_procedure_name(void far *procedure, char *buffer, size_t size);

--- a/include/dosdef.h
+++ b/include/dosdef.h
@@ -1,0 +1,46 @@
+#ifndef _DOSDEF_H_
+#define _DOSDEF_H_
+
+#include <assert.h>
+#include <stdint.h>
+
+#ifndef far
+#ifdef EDITING
+#define far
+#else // EDITING
+#define far __far
+#endif // EDITING
+#endif // far
+
+typedef enum
+{
+    STDOUT = 1,
+    STDERR = 2,
+} dos_stream;
+
+#pragma pack(push, 1)
+typedef struct
+{
+    char      int20h[2];
+    uint16_t  seg_tail;
+    uint8_t   _reserved1;
+    char      dispatch[5];
+    void far *intv_terminate;
+    void far *intv_break;
+    void far *intv_error;
+    char      _reserved2[22];
+    uint16_t  seg_environment;
+    char      _reserved3[34];
+    char      int21h_retf[3];
+    char      _reserved4[9];
+    char      fcb1[16];
+    char      fcb2[20];
+    uint8_t   cmdline_len;
+    char      cmdline[127];
+} dos_psp;
+#pragma pack(pop)
+
+static_assert(256 == sizeof(dos_psp),
+              "DOS PSP size doesn't match specification");
+
+#endif // _DOSDEF_H_

--- a/include/dosdef.h
+++ b/include/dosdef.h
@@ -2,6 +2,7 @@
 #define _DOSDEF_H_
 
 #include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifndef far

--- a/module/start.S
+++ b/module/start.S
@@ -60,3 +60,9 @@ exit_module:
     .global  andrea_exptabl
 andrea_exptabl:
     .word   exit_module
+
+
+    .section .preinit.str
+    .global  andrea_expstrs
+andrea_expstrs:
+    .byte 0


### PR DESCRIPTION
- store export name strings
- add procedure name retrieval function
- extend `andrea_get_procedure` to also retrieve with names
- use `_dos_spawn` instead of `_spawnl` (lower code footprint)