### PR TITLE
Free the environment block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
           git tag -l --format='%(contents:subject)' ${{ github.ref_name }} | sed -r "s/^.+: //" > common/RELEASE.md
   
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: andrea
           path: |
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Fetch build output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: andrea
           

--- a/host/load.c
+++ b/host/load.c
@@ -20,6 +20,12 @@ _set_psp(unsigned psp)
     __asm volatile("int $0x21" : : "a"(0x5000), "b"(psp) : "cc", "memory");
 }
 
+static unsigned
+_get_env(unsigned psp)
+{
+    return *(far uint16_t *)MK_FP(psp, 0x2C);
+}
+
 static int
 _load_module(const char *name, module_desc *desc)
 {
@@ -43,6 +49,9 @@ _load_module(const char *name, module_desc *desc)
     // Restore the parent PSP
     unsigned child = _get_psp();
     _set_psp(parent);
+
+    // Free the environment block
+    _dos_freemem(_get_env(child));
 
     // Find the header
     andrea_header far *header = __andrea_find_header(FP_SEG(spawn._proc._csip),


### PR DESCRIPTION
Release the environment block on module loading, to prevent conventional memory leak.

Fixes #14 